### PR TITLE
fix: stabilize unsupported-keyword error ordering

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -148,6 +148,7 @@ func (v *schemaValidator) TraverseSchema(schema SchemaDict, path schemaPath, cur
 	}
 
 	if len(unsupported) > 0 && (v.config.IsUltra() || v.config.IsTest()) {
+		sort.Strings(unsupported)
 		return currentDepth, v.context.RaiseErrorWithSimplify(fmt.Sprintf("unsupported keywords: %s", strings.Join(unsupported, ", ")), path, SimplifyDefault)
 	}
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -658,6 +658,18 @@ func TestUltraValidate(t *testing.T) {
 	}
 }
 
+func TestUltraUnsupportedKeywordsErrorOrderIsStable(t *testing.T) {
+	must := require.New(t)
+	validator := newSchemaValidator(WithValidateLevel(ValidateLevelUltra))
+	schema := `{"type":"object","zzz":1,"aaa":2}`
+
+	for i := 0; i < 30; i++ {
+		err := validator.Validate(schema)
+		must.Error(err)
+		must.Contains(strings.ToLower(err.Error()), "unsupported keywords: aaa, zzz")
+	}
+}
+
 func TestLiteAllowsMultipleTypesWithItems(t *testing.T) {
 	must := require.New(t)
 	schema := `{"additionalProperties": false, "properties": {"files": {"description": "List of files to read; request related files together when allowed", "items": {"additionalProperties": false, "properties": {"line_ranges": {"description": "Optional line ranges to read. Each range is a [start, end] tuple with 1-based inclusive line numbers. Use multiple ranges for non-contiguous sections.", "items": {"items": {"type": "integer"}, "maxItems": 2, "minItems": 2, "type": "array"}, "type": ["array", "null"]}, "path": {"description": "Path to the file to read, relative to the workspace", "type": "string"}}, "required": ["path", "line_ranges"], "type": "object"}, "minItems": 1, "type": "array"}}, "required": ["files"], "type": "object"}`


### PR DESCRIPTION
## Summary
- sort unsupported keyword names before formatting the error message
- add regression test to assert stable error text ordering

## Why
Map iteration order made `unsupported keywords: ...` output non-deterministic, which can cause flaky logs and tests.